### PR TITLE
Significant updates to documentation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,6 +2,7 @@ name = "FerriteIGA"
 uuid = "e7b8d123-e02a-40ba-ad18-d3943ed54f1c"
 version = "0.2.6"
 authors = ["Elias Börjesson <elias.isak.borjesson@gmail.com>"]
+description = "Isogeometric analysis for the Ferrite finite element library"
 
 [workspace]
 projects = ["test", "docs"]

--- a/README.md
+++ b/README.md
@@ -1,42 +1,68 @@
 # FerriteIGA.jl
 
-Small toolbox for Isogeometric analysis. Built on top of [Ferrite](https://github.com/Ferrite-FEM/Ferrite.jl)
+Isogeometric analysis in the [Ferrite](https://github.com/Ferrite-FEM/Ferrite.jl) finite element library.
 
 ## Documentation
 
 [![][docs-dev-img]][docs-dev-url]
 
-## Installation
-
-```
-Pkg.add(url="https://github.com/Ferrite-FEM/FerriteIGA.jl",rev="master")
-```
-
 [docs-dev-img]: https://img.shields.io/badge/docs-dev-blue.svg
 [docs-dev-url]: https://ferrite-fem.github.io/FerriteIGA.jl/dev/
 
-## Quick start
-The API is similar to Ferrite.jl:
+## Isogeometric analysis
+
+Hughes, Cottrell, and Bazilevs (2005) introduced isogeometric analysis as a Galerkin method whose basis is taken from CAD, consisting of B-splines and eventually non-uniform rational B-splines (Cottrell, Hughes, and Bazilevs, *Isogeometric Analysis* (Wiley, 2009)). A NURBS patch used for design is then available as an analysis mesh. NURBS can represent curved and conic sections such as cylinders, spheres, and circles exactly.
+Continuity is built into the knot vector, and the increased smoothness of IGA is a significant difference from standard finite elements.
+
+Spline functions overlap several neighbouring elements. A finite element code expects shape functions on a single cell. Bézier extraction (Borden, Scott, Evans, and Hughes, 2011) converts the B-spline or NURBS basis on each element into Bernstein polynomials. Those polynomials are local to the cell so the CAD geometry can be used in Ferrite. 
+
+## Installation
+
+The package is unregistered. From the Pkg REPL,
 
 ```
+pkg> add https://github.com/Ferrite-FEM/FerriteIGA.jl
+```
+
+Ferrite is installed as a dependency.
+
+## Quick start
+
+Generate a NURBS patch, convert it to a Bézier mesh, and build cell values.
+
+```julia
 using Ferrite, FerriteIGA
 
 order = 2 # second order NURBS
-nels = (20,10) # Number of elements
-patch = generate_nurbs_patch(:plate_with_hole, nels, order) 
+nels = (20, 10) # number of elements
+patch = generate_nurbs_patch(:plate_with_hole, nels, order)
 
-#Convert nurbs patch to a Grid structure with bezier-extraction operators
+# Convert the NURBS patch to a grid with Bézier extraction operators
 grid = BezierGrid(patch)
 
-#Create interpolation and shape values
-ip = IGAInterpolation{RefQuadrilateral,order}() #Bernstein polynomials
-qr_cell = QuadratureRule{RefQuadrilateral}(4)
+# Interpolation and shape values (Bernstein polynomials)
+ip = IGAInterpolation{RefQuadrilateral, order}()
+qr = QuadratureRule{RefQuadrilateral}(4)
+cv = BezierCellValues(qr, ip)
 
-cv = BezierCellValues(qr_cell, ip, update_hessians=true)
-
-#...
-#update cell values
-coords::BezierCoords = getcoordinates(grid, 1)
+# Update cell values
+coords = getcoordinates(grid, 1)
 reinit!(cv, coords)
-
 ```
+
+`reinit!` applies the extraction. After that call the cell values are used as in Ferrite.
+
+A uniform box can also be built with `generate_grid` and a `BezierCell`.
+
+```julia
+grid = generate_grid(BezierCell{RefLine, 2}, (10,), Vec(0.0), Vec(1.0))
+```
+
+`generate_nurbs_patch` also provides lines, rectangles, cubes, rings, cylindrical sectors, a plate with a circular hole, and several singly and doubly curved shells.
+
+## References
+
+- T. J. R. Hughes, J. A. Cottrell, and Y. Bazilevs. Isogeometric analysis. CAD, finite elements, NURBS, exact geometry and mesh refinement. *Comput. Methods Appl. Mech. Engrg.*, 194:4135–4195, 2005. [doi:10.1016/j.cma.2004.10.008](https://doi.org/10.1016/j.cma.2004.10.008)
+- J. A. Cottrell, A. Reali, Y. Bazilevs, and T. J. R. Hughes. Isogeometric analysis of structural vibrations. *Comput. Methods Appl. Mech. Engrg.*, 195:5257–5296, 2006. [doi:10.1016/j.cma.2005.09.027](https://doi.org/10.1016/j.cma.2005.09.027)
+- M. J. Borden, M. A. Scott, J. A. Evans, and T. J. R. Hughes. Isogeometric finite element data structures based on Bézier extraction of NURBS. *Int. J. Numer. Meth. Engng.*, 87:15–47, 2011. [doi:10.1002/nme.2968](https://doi.org/10.1002/nme.2968)
+- J. A. Cottrell, T. J. R. Hughes, and Y. Bazilevs. *Isogeometric Analysis. Toward Integration of CAD and FEA*. Wiley, 2009. [doi:10.1002/9780470749081](https://doi.org/10.1002/9780470749081)

--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ Isogeometric analysis in the [Ferrite](https://github.com/Ferrite-FEM/Ferrite.jl
 
 ## Isogeometric analysis
 
-Hughes, Cottrell, and Bazilevs (2005) introduced isogeometric analysis as a Galerkin method whose basis is taken from CAD, consisting of B-splines and eventually non-uniform rational B-splines (Cottrell, Hughes, and Bazilevs, *Isogeometric Analysis* (Wiley, 2009)). A NURBS patch used for design is then available as an analysis mesh. NURBS can represent curved and conic sections such as cylinders, spheres, and circles exactly.
-Continuity is built into the knot vector, and the increased smoothness of IGA is a significant difference from standard finite elements.
+Hughes, Cottrell, and Bazilevs (2005) introduced isogeometric analysis as a Galerkin method whose basis is taken from CAD, consisting of B-splines and non-uniform rational B-splines (Cottrell, Hughes, and Bazilevs, *Isogeometric Analysis* (Wiley, 2009)). A NURBS patch from CAD design can then be used as the analysis mesh. NURBS can represent curved and conic sections such as cylinders, spheres, and circles exactly. The increased smoothness of IGA is a significant difference from traditional finite elements.
 
 Spline functions overlap several neighbouring elements. A finite element code expects shape functions on a single cell. Bézier extraction (Borden, Scott, Evans, and Hughes, 2011) converts the B-spline or NURBS basis on each element into Bernstein polynomials. Those polynomials are local to the cell so the CAD geometry can be used in Ferrite. 
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,8 +15,9 @@ makedocs(
     warnonly = true,
     pages = Any[
         "Home" => "index.md",
-        "Manual" => ["splines.md", "bezier_extraction.md"],
+        "Manual" => ["splines.md", "meshes.md", "bezier_extraction.md"],
         "Examples" => GENERATEDEXAMPLES,
+        "API" => "api.md",
     ]
 )
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,0 +1,19 @@
+# API
+
+FerriteIGA types and functions. After `reinit!`, assembly follows the [Ferrite manual](https://ferrite-fem.github.io/Ferrite.jl/stable/).
+
+```@docs
+NURBSMesh
+generate_nurbs_patch
+BezierGrid
+BezierCoords
+BezierCell
+IGAInterpolation
+BezierCellValues
+BezierFacetValues
+VTKIGAFile
+knotinsertion!
+orderelevation!
+smoothnesselevation!
+eval_parametric_coordinate
+```

--- a/docs/src/bezier_extraction.md
+++ b/docs/src/bezier_extraction.md
@@ -1,6 +1,6 @@
 # Bezier extraction
 
-A B-spline or NURBS function of degree $p$ overlaps several neighbouring knot spans. Ferrite evaluates shape functions one cell at a time. Bézier extraction ([Borden, Scott, Evans, and Hughes, 2011](https://doi.org/10.1002/nme.2968)) writes the spline basis on an element in terms of Bernstein polynomials. Those polynomials are $C^0$ and live on one cell, so the geometry can be integrated like a standard finite element mesh. The higher smoothness between cells is kept.
+A B-spline or NURBS function of degree $p$ overlaps several neighbouring knot spans. Ferrite evaluates shape functions one cell at a time. Bézier extraction ([Borden, Scott, Evans, and Hughes, 2011](https://doi.org/10.1002/nme.2968)) writes the spline basis on an element in terms of Bernstein polynomials. Those polynomials are $C^0$ and are local one cell, so the geometry can be integrated like a standard finite element mesh. The higher smoothness between cells is kept geometrically.
 
 The extraction operator $\boldsymbol{C}^e$ is built from the knot vector once per cell. `BezierGrid` stores it. `IGAInterpolation` is the Bernstein basis. `BezierCellValues` applies $\boldsymbol{C}^e$ in `reinit!`.
 
@@ -43,7 +43,7 @@ The geometry can then be written in either basis,
 \boldsymbol{S}(\xi) = \sum_A R_A(\xi)\, \boldsymbol{X}_A = \sum_A B_A(\xi)\, \boldsymbol{X}_{b,A}.
 ```
 
-Bernstein values are tabulated at quadrature points, as in Ferrite. Multiplication by $\boldsymbol{C}^e$ and the weights gives the NURBS values used in the weak form.
+Bernstein values are stored at quadrature points, as in Ferrite. Multiplication by $\boldsymbol{C}^e$ and the weights gives the NURBS values used in the weak form.
 
 ## Usage
 

--- a/docs/src/bezier_extraction.md
+++ b/docs/src/bezier_extraction.md
@@ -1,52 +1,87 @@
 # Bezier extraction
 
-The basefunctions used in IGA (B-splines, NURBS, etc.) exist over multiple adjecent elements. This is in contrast to traditional finite element method, where identical shape function are defined withing all elements. This makes it difficult to incorprate IGA in to a standard finite element code. The bezier extraction technique, introduced by [Borden et.al](https://doi.org/10.1002/nme.2968), solves this problem by allowing numerical integration of smooth function to be performed on C0 Bezier elements.
+A B-spline or NURBS function of degree $p$ overlaps several neighbouring knot spans. Ferrite evaluates shape functions one cell at a time. Bézier extraction ([Borden, Scott, Evans, and Hughes, 2011](https://doi.org/10.1002/nme.2968)) writes the spline basis on an element in terms of Bernstein polynomials. Those polynomials are $C^0$ and live on one cell, so the geometry can be integrated like a standard finite element mesh. The higher smoothness between cells is kept.
 
-The $C^p$-continiuos B-Spline basis functions on an element, $\boldsymbol N^e$ can be computeded from the $C^0$ bernstein polynominals, $\boldsymbol B^e$, as
+The extraction operator $\boldsymbol{C}^e$ is built from the knot vector once per cell. `BezierGrid` stores it. `IGAInterpolation` is the Bernstein basis. `BezierCellValues` applies $\boldsymbol{C}^e$ in `reinit!`.
 
-```math
-    \boldsymbol N^e = \boldsymbol C^e \boldsymbol B^e
-```
+## B-spline basis on an element
 
-where $\boldsymbol C^e$ is the bezier extraction operator for the current cell. This operator can be pre-computed for each element in the IGA-mesh. With the help of this relation, it can be shown that the NURBS can be computed as 
+On element $e$,
 
 ```math
-    \boldsymbol R^e = \boldsymbol W^e \frac{ \boldsymbol N^e}{W(\xi)} = \boldsymbol W^e \boldsymbol C^e \frac{\boldsymbol B^e}{W^b(\xi)}
+\boldsymbol{N}^e = \boldsymbol{C}^e \boldsymbol{B}^e,
 ```
 
-where $\boldsymbol W^e$ is a diagonal matrix of the rational weights, $w_I, I = 1,2,\dots,N$, and $W(\xi)$ and $W^b(\xi)$ are the weight functions 
+where $\boldsymbol{N}^e$ are the B-spline functions on the element and $\boldsymbol{B}^e$ are the Bernstein polynomials of the same degree. $\boldsymbol{C}^e$ is sparse. In 2D and 3D it is built from the 1D operators in each direction (`compute_bezier_extraction_operators`).
+
+## NURBS
+
+NURBS place a weight $w_A$ at each control point. Let $\boldsymbol{W}^e$ be the diagonal matrix of those weights on the element. The rational basis is
 
 ```math
-    W(\xi) = W^b(\xi) = \sum_I^N = N(\xi)  w_I = \sum_I^N = B(\xi)  w^b_I . 
+\boldsymbol{R}^e = \boldsymbol{W}^e \frac{\boldsymbol{N}^e}{W(\xi)} = \boldsymbol{W}^e \boldsymbol{C}^e \frac{\boldsymbol{B}^e}{W^b(\xi)},
 ```
 
-It can also be show that a NURBS-surface (or curve/solid) can be represented using the Bernstein basis functions,
+with weight functions
 
 ```math
-    S(\xi, \eta) = \boldsymbol X^e \boldsymbol R(\xi, \eta) = \boldsymbol X_b^e \boldsymbol B(\xi, \eta)
+W(\xi) = \sum_A N_A(\xi)\, w_A, \qquad
+W^b(\xi) = \sum_A B_A(\xi)\, w^b_A.
 ```
 
-where $\boldsymbol X^e$ are the control points for the NURBS surface, and $\boldsymbol X_b^e$ are controlpoints on the bezier element, caluculated as 
+The two sums are equal, $W(\xi) = W^b(\xi)$. Applying $(\boldsymbol{C}^e)^{T}$ to the NURBS data gives the Bézier weights and control points,
 
 ```math
-    \boldsymbol X_b^e = \frac{1}{W(\xi)} \left(\boldsymbol C^e\right)^T \boldsymbol W^e \boldsymbol X^e
+\boldsymbol{w}^b = (\boldsymbol{C}^e)^{T} \boldsymbol{w},
+\qquad
+w^b_A \boldsymbol{X}_{b,A} = \sum_B C^e_{BA}\, w_B \boldsymbol{X}_B.
 ```
 
-The equations above show that we can pre-compute the bernstein basis values at some gauss points (similar to how we pre compute the shape values for Lagrange basis functions), and then using the bezier extraction operator, calculate the NURBS values. In the code, the reinitilzation of the shape functions is performed like this.
+The geometry can then be written in either basis,
 
-```@example
-ip = Bernstein{2,orders}()
-qr_cell = QuadratureRule{2,RefCube}(4)
+```math
+\boldsymbol{S}(\xi) = \sum_A R_A(\xi)\, \boldsymbol{X}_A = \sum_A B_A(\xi)\, \boldsymbol{X}_{b,A}.
+```
 
-cv = BezierCellValues( CellVectorValues(qr_cell, ip) )
+Bernstein values are tabulated at quadrature points, as in Ferrite. Multiplication by $\boldsymbol{C}^e$ and the weights gives the NURBS values used in the weak form.
 
-#...
+## Usage
 
-extr = get_extraction_operator(grid, cellid) # Extraction operator
-X = getcoordinates(grid, cellid) #Nurbs coords
-w = getweights(grid, cellid)       #Nurbs weights
-wᴮ = compute_bezier_points(extr, w)
-Xᴮ = inv.(wᴮ) .* compute_bezier_points(extr, w.*X)
+`BezierGrid(patch)` turns a NURBS patch into a Ferrite grid. Each cell keeps its weights and the extraction operator $\boldsymbol{C}^e$. An ordinary Ferrite grid can be passed as `BezierGrid(grid)`.
 
-reinit!(cv, (Xᴮ, wᴮ))
+`getcoordinates(grid, cellid)` returns a `BezierCoords` for that cell. `x` and `w` are the NURBS points and weights. `xb` and `wb` are the Bézier points and weights. `beo` is the operator.
+
+`reinit!(cv, coords)` uses that data to fill the shape functions.
+
+`IGAInterpolation{shape, p}()` is the Bernstein basis of degree $p$. `shape` is `RefLine`, `RefQuadrilateral`, or `RefHexahedron`. For a vector unknown write `ip^2`.
+
+`BezierCellValues(qr, ip)` stores the basis at the quadrature points in `qr`. `reinit!` applies $\boldsymbol{C}^e`. On faces use `BezierFacetValues` and `reinit!(fv, coords, faceid)`.
+
+```julia
+using Ferrite, FerriteIGA
+
+order = 2 # second order NURBS
+nels = (20, 10) # number of elements
+patch = generate_nurbs_patch(:plate_with_hole, nels, order)
+
+# Convert the NURBS patch to a grid with Bézier extraction operators
+grid = BezierGrid(patch)
+
+# Interpolation and shape values (Bernstein polynomials)
+ip = IGAInterpolation{RefQuadrilateral, order}()
+qr = QuadratureRule{RefQuadrilateral}(4)
+cv = BezierCellValues(qr, ip)
+
+# Update cell values
+coords = getcoordinates(grid, 1)
+reinit!(cv, coords)
+```
+
+After `reinit!`, `shape_value` and `shape_gradient` give NURBS values. Assembly then follows Ferrite (`DofHandler`, `ConstraintHandler`, `start_assemble`). See the [Ferrite manual](https://ferrite-fem.github.io/Ferrite.jl/stable/).
+
+Displacement fields on a `BezierGrid` are written with `VTKIGAFile`.
+```julia
+VTKIGAFile("plate_with_hole.vtu", grid) do vtk
+    write_solution(vtk, dh, u)
+end
 ```

--- a/docs/src/bezier_values.md
+++ b/docs/src/bezier_values.md
@@ -1,3 +1,0 @@
-# BezierValues.jl
-
-Documentation for FerriteIGA.jl

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -10,17 +10,17 @@ The [Splines](@ref), [Meshes](@ref), and [Bezier extraction](@ref) pages expand 
 
 Hughes, Cottrell, and Bazilevs (2005) introduced isogeometric analysis as a Galerkin method whose basis is taken from CAD, consisting of B-splines and eventually non-uniform rational B-splines (Cottrell, Hughes, and Bazilevs, *Isogeometric Analysis* (Wiley, 2009)). A NURBS patch used for design is then available as an analysis mesh. NURBS can represent curved and conic sections such as cylinders, spheres, and circles exactly.
 
-Continuity is built into the knot vector, and the increased smoothness of IGA is a significant difference from standard finite elements. A B-spline of degree $p$ is $C^{p-m}$ at a knot of multiplicity $m$. With simple interior knots the basis is $C^{p-1}$ across element boundaries.
+Continuity is built into the knot vector, and the increased smoothness of IGA is a significant difference from standard finite elements. 
 
-In linear elasticity the stress follows from derivatives of the displacement. In a $C^0$ mesh those derivatives jump at element edges, which affects stress concentrations and bending curvature. A $C^{p-1}$ patch keeps strains and stresses continuous inside the patch. Thin shells that use second derivatives of the displacement need at least $C^1$. The [Infinite plate with hole](@ref) is a plane-stress problem with a circular hole that NURBS represent exactly.
+In linear elasticity the stress comes from derivatives of the displacement. In a standard $C^0$ mesh these derivatives jump at element edges, which affects stress concentrations and bending curvature. A higher-order smoothness patch keeps strains and stresses continuous inside the patch. Thin shells that use second derivatives of the displacement need at least continuity $C^1$. The [Infinite plate with hole](@ref) is a plane-stress problem with a circular hole that NURBS represent exactly.
 
-The same smoothness shows up in vibration spectra. After discretization the natural frequencies satisfy $(\boldsymbol{K} - \omega_n^2 \boldsymbol{M})\boldsymbol{\phi}_n = 0$. For an elastic rod of unit length the exact frequencies are $\omega_n = n\pi$. Cottrell et al. (2006) showed that a $C^{p-1}$ spline space of degree $p$ keeps the higher computed eigenfrequencies closer to this spectrum than a $C^0$ finite element space of the same degree, which drifts once the mode number exceeds about half the number of degrees of freedom. The [structural vibrations](@ref structural_vibrations) example repeats that rod calculation.
+The same smoothness provides another advantage in the eigenvalue spectrum and vibration problems. Cottrell et al. (2006) showed that the spline discretization produces an eigenvalue/frequency spectrum closer to the exact spectrum of the problem than a $C^0$ finite element space of the same degree, which drifts once the mode number exceeds about half the number of degrees of freedom. The [structural vibrations](@ref structural_vibrations) example shows the vibration spectrum of IGA.
 
 The mesh can undergo knot insertion (h-refinement), order elevation (p-refinement), or a combination of both to increase smoothness (k-refinement).
 
 ## Bézier extraction
 
-Spline functions overlap several neighbouring elements. A finite element code expects shape functions on a single cell. Bézier extraction (Borden, Scott, Evans, and Hughes, 2011) converts the B-spline or NURBS basis on each element into Bernstein polynomials. Those polynomials are local to the cell and $C^0$, so the isogeometric geometry can be used in Ferrite. The extraction data is stored on a `BezierGrid` and applied in `reinit!`.
+Spline functions overlap several neighbouring elements. A finite element code expects shape functions on a single cell. Bézier extraction (Borden, Scott, Evans, and Hughes, 2011) converts the B-spline or NURBS basis on each element into Bernstein polynomials. Those polynomials are local to the cell and $C^0$, so the isogeometric geometry can be used in Ferrite.
 
 ## Installation
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,21 +1,74 @@
 # FerriteIGA.jl
 
-Small toolbox for Isogeometric anlysis. Built on top of [Ferrite](https://github.com/ferrite-fem/Ferrite.jl)
+Isogeometric analysis in the [Ferrite](https://github.com/Ferrite-FEM/Ferrite.jl) finite element library.
+
+The basis is a B-spline or NURBS space, the same functions used for CAD geometry. Degrees of freedom, constraints, and assembly use the Ferrite interface. Bézier extraction converts the splines into Bernstein polynomials so the geometry works with a standard finite element code.
+
+The [Splines](@ref), [Meshes](@ref), and [Bezier extraction](@ref) pages expand the topics below. Examples include the [Infinite plate with hole](@ref) and [structural vibrations](@ref structural_vibrations) of an elastic rod.
+
+## Isogeometric analysis
+
+Hughes, Cottrell, and Bazilevs (2005) introduced isogeometric analysis as a Galerkin method whose basis is taken from CAD, consisting of B-splines and eventually non-uniform rational B-splines (Cottrell, Hughes, and Bazilevs, *Isogeometric Analysis* (Wiley, 2009)). A NURBS patch used for design is then available as an analysis mesh. NURBS can represent curved and conic sections such as cylinders, spheres, and circles exactly.
+
+Continuity is built into the knot vector, and the increased smoothness of IGA is a significant difference from standard finite elements. A B-spline of degree $p$ is $C^{p-m}$ at a knot of multiplicity $m$. With simple interior knots the basis is $C^{p-1}$ across element boundaries.
+
+In linear elasticity the stress follows from derivatives of the displacement. In a $C^0$ mesh those derivatives jump at element edges, which affects stress concentrations and bending curvature. A $C^{p-1}$ patch keeps strains and stresses continuous inside the patch. Thin shells that use second derivatives of the displacement need at least $C^1$. The [Infinite plate with hole](@ref) is a plane-stress problem with a circular hole that NURBS represent exactly.
+
+The same smoothness shows up in vibration spectra. After discretization the natural frequencies satisfy $(\boldsymbol{K} - \omega_n^2 \boldsymbol{M})\boldsymbol{\phi}_n = 0$. For an elastic rod of unit length the exact frequencies are $\omega_n = n\pi$. Cottrell et al. (2006) showed that a $C^{p-1}$ spline space of degree $p$ keeps the higher computed eigenfrequencies closer to this spectrum than a $C^0$ finite element space of the same degree, which drifts once the mode number exceeds about half the number of degrees of freedom. The [structural vibrations](@ref structural_vibrations) example repeats that rod calculation.
+
+The mesh can undergo knot insertion (h-refinement), order elevation (p-refinement), or a combination of both to increase smoothness (k-refinement).
+
+## Bézier extraction
+
+Spline functions overlap several neighbouring elements. A finite element code expects shape functions on a single cell. Bézier extraction (Borden, Scott, Evans, and Hughes, 2011) converts the B-spline or NURBS basis on each element into Bernstein polynomials. Those polynomials are local to the cell and $C^0$, so the isogeometric geometry can be used in Ferrite. The extraction data is stored on a `BezierGrid` and applied in `reinit!`.
 
 ## Installation
 
-pkg> add https://github.com/ferrite-fem/FerriteIGA.jl.git
+The package is unregistered. From the Pkg REPL,
 
-## About IGA
+```
+pkg> add https://github.com/Ferrite-FEM/FerriteIGA.jl
+```
 
-Isogeometric analysis uses the same basis functions that describe geometry in CAD, such as B-splines or NURBS, as the basis for the finite-dimensional solution space in analysis. The geometry map and the unknown fields are expressed in the common basis, which reduces the friction between design models and analysis meshes and avoids repeated mesh generation steps that appear when CAD geometry needs to be translated to elements. NURBS additionally preserve exact conic geometry, which matters for shells, cylinders, and circular inclusions where polygonal meshing introduces geometric error even before the PDE is solved.
+Ferrite is installed as a dependency.
 
-Additionally, spline-based discretizations offer higher continuity across element boundaries by construction rather than being limited to C0 continuity at inter-element interfaces in the most FEM spaces. This global or patchwise smoothness can improve the representation of stresses and curvatures in bending-dominated elasticity and thin structures, where low-order C0 elements often need many layers through the thickness or special elements to avoid locking and poor stress resolution. 
+## Quick start
 
-Furthermore, the smoother approximation spaces also affect spectral problems. Modal analysis and vibration problems solved with isogeometric discretizations often show improved accuracy per degree of freedom and eigenvalue spectra that converge more favorably in the higher modes than comparable low-order finite elements, because the basis can represent oscillatory eigenfunctions with less numerical dispersion in some regimes. The [Structural vibrations](@ref structural_vibrations) demonstrates this for an elastic rod.
+Generate a NURBS patch, convert it to a Bézier mesh, and build cell values.
 
-IGA is not uniformly superior to FEM in every setting. For example, refinement is tied to knot insertion or degree elevation, boundary conditions and constraints need careful treatment on spline spaces, and the extra continuity and cost may not be warranted for some problems. The point is that for many problems where CAD fidelity, smoothness, or spectral quality matter, isogeometric analysis is a natural extension of finite element ideas with a different choice of basis.
+```julia
+using Ferrite, FerriteIGA
 
-### Reference
+order = 2 # second order NURBS
+nels = (20, 10) # number of elements
+patch = generate_nurbs_patch(:plate_with_hole, nels, order)
 
-J. Austin Cottrell, Thomas J. R. Hughes, and Yuri Bazilevs. *Isogeometric Analysis: Toward Integration of CAD and FEA*. Chichester, UK: John Wiley & Sons, 2009. ISBN 978-0-470-74873-2 (hardcover). DOI [10.1002/9780470749081](https://doi.org/10.1002/9780470749081).
+# Convert the NURBS patch to a grid with Bézier extraction operators
+grid = BezierGrid(patch)
+
+# Interpolation and shape values (Bernstein polynomials)
+ip = IGAInterpolation{RefQuadrilateral, order}()
+qr = QuadratureRule{RefQuadrilateral}(4)
+cv = BezierCellValues(qr, ip)
+
+# Update cell values
+coords = getcoordinates(grid, 1)
+reinit!(cv, coords)
+```
+
+`reinit!` applies the extraction. After that call, `DofHandler`, `ConstraintHandler`, and assembly follow the [Ferrite documentation](https://ferrite-fem.github.io/Ferrite.jl/stable/).
+
+A uniform box can also be built with `generate_grid` and a `BezierCell`.
+
+```julia
+grid = generate_grid(BezierCell{RefLine, 2}, (10,), Vec(0.0), Vec(1.0))
+```
+
+`generate_nurbs_patch` also provides lines, rectangles, cubes, rings, cylindrical sectors, a plate with a circular hole, and several singly and doubly curved shells. The full list is on the [Meshes](@ref) page.
+
+## References
+
+- T. J. R. Hughes, J. A. Cottrell, and Y. Bazilevs. Isogeometric analysis. CAD, finite elements, NURBS, exact geometry and mesh refinement. *Comput. Methods Appl. Mech. Engrg.*, 194:4135–4195, 2005. [doi:10.1016/j.cma.2004.10.008](https://doi.org/10.1016/j.cma.2004.10.008)
+- J. A. Cottrell, A. Reali, Y. Bazilevs, and T. J. R. Hughes. Isogeometric analysis of structural vibrations. *Comput. Methods Appl. Mech. Engrg.*, 195:5257–5296, 2006. [doi:10.1016/j.cma.2005.09.027](https://doi.org/10.1016/j.cma.2005.09.027)
+- M. J. Borden, M. A. Scott, J. A. Evans, and T. J. R. Hughes. Isogeometric finite element data structures based on Bézier extraction of NURBS. *Int. J. Numer. Meth. Engng.*, 87:15–47, 2011. [doi:10.1002/nme.2968](https://doi.org/10.1002/nme.2968)
+- J. A. Cottrell, T. J. R. Hughes, and Y. Bazilevs. *Isogeometric Analysis. Toward Integration of CAD and FEA*. Wiley, 2009. [doi:10.1002/9780470749081](https://doi.org/10.1002/9780470749081)

--- a/docs/src/literate/plate_with_hole.jl
+++ b/docs/src/literate/plate_with_hole.jl
@@ -17,7 +17,7 @@ using Ferrite, FerriteIGA, LinearAlgebra
 # Next we define the functions for the integration of the element stiffness matrix and traction force.
 # These functions will be the same as for a normal finite elment problem, but
 # with the difference that we need the cell coorinates AND cell weights (the weights from the NURBS shape functions), to reinitilize the shape values, dNdx.
-# Read this [`page`](../bezier_values.md), to see how the shape values are reinitilized. 
+# See [Bezier extraction](@ref) for how the shape values are reinitialized. 
 function integrate_element!(ke::AbstractMatrix, C::SymmetricTensor{4,2}, cv)
     n_basefuncs = getnbasefunctions(cv)
 
@@ -161,8 +161,7 @@ addfacetset!(grid, "left", (x) -> x[1] ≈ -4.0)
 addfacetset!(grid, "bot", (x) -> x[2] ≈ 0.0)
 addfacetset!(grid, "right", (x) -> x[1] ≈ 0.0);
 
-# Create the cellvalues storing the shape function values. Note that the `CellVectorValues`/`FaceVectorValues` are wrapped in a `BezierValues`. It is in the 
-# reinit-function of the `BezierValues` that the actual bezier transformation of the shape values is performed. 
+# Cell and facet values. `reinit!` applies Bézier extraction, after which `shape_value` and `shape_gradient` return NURBS quantities. 
 ip_geo = IGAInterpolation{RefQuadrilateral,order}()
 ip_u = ip_geo^2
 qr_cell = QuadratureRule{RefQuadrilateral}(4)

--- a/docs/src/meshes.md
+++ b/docs/src/meshes.md
@@ -1,0 +1,66 @@
+# Meshes
+
+Geometry starts as a `NURBSMesh`. Convert it with `BezierGrid(mesh)` before assembly. Straight boxes can also use `generate_grid` with a `BezierCell`. Refinement is on the [Splines](@ref) page.
+
+## `generate_nurbs_patch`
+
+```julia
+patch = generate_nurbs_patch(name, nels, order; kwargs...)
+```
+
+`name` is a symbol. `nels` is how many elements in each direction. `order` is the degree, or a tuple if the degree differs by direction.
+
+### Boxes
+
+`:line`, `:rectangle`, `:cube`, and `:hypercube` are straight patches. `:line` is 1D, `:rectangle` is 2D, `:cube` is 3D. `:hypercube` covers all three.
+
+`cornerpos` is the lower corner and `size` is the side lengths. `multiplicity` repeats interior knots. `sdim` puts a 1D or 2D patch into 2D or 3D.
+
+```julia
+generate_nurbs_patch(:rectangle, (8, 4), 2; cornerpos=(0.0, 0.0), size=(2.0, 1.0))
+generate_nurbs_patch(:cube, (4, 4, 4), 2; cornerpos=(-1.0, -1.0, -1.0), size=(2.0, 2.0, 2.0))
+```
+
+The same boxes with `generate_grid`:
+
+```julia
+generate_grid(BezierCell{RefLine, 2}, (10,), Vec(0.0), Vec(1.0))
+generate_grid(BezierCell{RefQuadrilateral, 2}, (8, 4), Vec(0.0, 0.0), Vec(2.0, 0.0), Vec(2.0, 1.0), Vec(0.0, 1.0))
+generate_grid(BezierCell{RefHexahedron, 2}, (4, 4, 4), Vec(-1.0, -1.0, -1.0), Vec(1.0, 1.0, 1.0))
+```
+
+### Curved patches
+
+`:singly_curved` is an arc with thickness. In 2D the keywords are `α` (angle), `R` (radius), and `thickness`. In 3D add `width`.
+
+`:singly_curved_shell` is a 3D surface (no thickness) with `α`, `R`, and `width`.
+
+`:singly_curved_beam` is a 1D arc in the plane, with `α` and `R`.
+
+`:doubly_curved` is a 3D surface with two radii and two angles, `r1`, `r2`, `α1`, `α2`.
+
+`:doubly_curved_nurbs` is a quadratic NURBS surface (`r1`, `r2`, `α2`). The degree is fixed.
+
+### Exact circles
+
+`:plate_with_hole` is a quarter plate with a circular hole of radius 1, outer size 4. The degree is 2. The first entry of `nels` must be even and at least 2.
+
+```julia
+generate_nurbs_patch(:plate_with_hole, (20, 10), 2)
+```
+
+`:ring` is a circular ring. The element count is fixed at `(4, 1)` and the degree at 2. Set inner and outer radii with `ri` and `ro`.
+
+```julia
+generate_nurbs_patch(:ring, (4, 1), 2; ri=1.0, ro=2.0)
+```
+
+`:cylinder_sector` is a half-cylinder solid. The degree is 2. `L` is the length, `r` the radius, and `x0` the start of the axis (default `-L/2`). `nels[2]` (around the circle) must be even and greater than 2. `nels[3]` must be greater than 1.
+
+```julia
+generate_nurbs_patch(:cylinder_sector, (4, 4, 2), 2; L=2.0, r=1.0)
+```
+
+## Parameter maps
+
+`eval_parametric_coordinate(mesh, ξ)` maps a parameter `ξ` to a physical point. `parent_to_parametric_map(mesh, cellid, xi)` maps a point on the reference cell into the knot vector.

--- a/docs/src/meshes.md
+++ b/docs/src/meshes.md
@@ -41,7 +41,7 @@ generate_grid(BezierCell{RefHexahedron, 2}, (4, 4, 4), Vec(-1.0, -1.0, -1.0), Ve
 
 `:doubly_curved_nurbs` is a quadratic NURBS surface (`r1`, `r2`, `α2`). The degree is fixed.
 
-### Exact circles
+### Circles and cylinders
 
 `:plate_with_hole` is a quarter plate with a circular hole of radius 1, outer size 4. The degree is 2. The first entry of `nels` must be even and at least 2.
 

--- a/docs/src/splines.md
+++ b/docs/src/splines.md
@@ -1,46 +1,48 @@
 # Splines
 
+Isogeometric analysis uses B-splines and NURBS as the discrete basis. A one-dimensional spline is built from a knot vector and a polynomial degree. Surfaces and solids are products of these one-dimensional functions. Control points set the shape. NURBS add a positive weight at each control point, which is what allows exact circles and other conic sections.
+
+The patch type is a `NURBSMesh`. After Bézier extraction, see [Bezier extraction](@ref), assembly follows the [Ferrite documentation](https://ferrite-fem.github.io/Ferrite.jl/stable/).
+
 ## B-splines
 
-The univariate **B-spline** basis is defined on a knot vector of length $n+p+1$, a non-decreasing sequence of parametric coordinates
-$\Xi = [\xi_1, \ldots, \xi_{n+p+1}]$, where $p$ is the polynomial degree of the basis and $n$ is the number of basis functions.
-At an **interior** knot value of multiplicity $m$ with $1 \leq m \leq p+1$, any spline curve of degree $p$ constructed from this knot vector is $C^{p-m}$-continuous across that knot: derivatives of order $0,\ldots,p-m$ agree from the left and right, while derivatives of order greater than $p-m$ may jump.
-Endpoint multiplicities and the **open knot-vector** convention are treated in the section on open knot vectors below.
-The B-splines are defined recursively through Cox-de-Boor recursion:
+A **knot vector** of degree $p$ with $n$ basis functions is a sequence of length $n+p+1$,
 
 ```math
-\hat{N}_{A,p}(\xi) = \frac{\xi - \xi_A}{\xi_{A+p} - \xi_A} \, \hat{N}_{A,p-1}(\xi) + \frac{\xi_{A+p+1} - \xi}{\xi_{A+p+1} - \xi_{A+1}} \, \hat{N}_{A+1,p-1}(\xi)
+\Xi = [\xi_1, \ldots, \xi_{n+p+1}].
 ```
 
-with the piecewise constant case:
+Each interval $\xi_i < \xi_{i+1}$ is one element. Repeating a knot value raises its multiplicity $m$. At an interior knot of multiplicity $m$, with $1 \leq m \leq p+1$, a spline of degree $p$ is $C^{p-m}$. Derivatives through order $p-m$ match from the left and right. Higher derivatives may jump. A simple knot ($m=1$) gives $C^{p-1}$ continuity across that element boundary.
+
+The B-spline basis is defined by the Cox–de Boor recursion. For $p=0$,
 
 ```math
 \hat{N}_{A,0}(\xi) =
 \begin{cases}
 1 & \text{if } \xi_A \leq \xi < \xi_{A+1}, \\
-0 & \text{otherwise}.
+0 & \text{otherwise},
 \end{cases}
 ```
 
-With the usual convention at the right end of the parametric domain so that the basis forms a partition of unity.
-
-B-spline basis functions are used to represent geometry (curves, surfaces, and solids). For example, a B-spline surface has the form:
+The functions sum to one, $\sum_A \hat{N}_{A,p}(\xi) = 1$, with the last knot interval closed on the right. For $p \geq 1$,
 
 ```math
-\boldsymbol{S}(\xi,\eta) = \sum_{A=1}^{N} \boldsymbol{X}_A \, N_A(\xi, \eta)
+\hat{N}_{A,p}(\xi) = \frac{\xi - \xi_A}{\xi_{A+p} - \xi_A} \, \hat{N}_{A,p-1}(\xi) + \frac{\xi_{A+p+1} - \xi}{\xi_{A+p+1} - \xi_{A+1}} \, \hat{N}_{A+1,p-1}(\xi).
 ```
 
-where $\boldsymbol{X}_A$ are the control points and $N_A$ is a tensor product of univariate B-splines in the two parametric directions:
+
+A B-spline surface is a product of one-dimensional bases. With control points $\boldsymbol{X}_A$ and global index $A$ for the pair $(i,j)$,
 
 ```math
+\boldsymbol{S}(\xi,\eta) = \sum_{A=1}^{N} \boldsymbol{X}_A \, N_A(\xi, \eta),
+\qquad
 N_A(\xi, \eta) = \hat{N}_{i}^{(\xi)}(\xi) \, \hat{N}_{j}^{(\eta)}(\eta).
 ```
 
-Here $\hat{N}_{i}^{(\xi)}$ and $\hat{N}_{j}^{(\eta)}$ use knot vectors $\Xi^{(\xi)}$ and $\Xi^{(\eta)}$ (and degrees $p_\xi$, $p_\eta$) associated with the index pair $(i,j)$ that corresponds to the global basis index $A$.
-
+The factors $\hat{N}_{i}^{(\xi)}$ and $\hat{N}_{j}^{(\eta)}$ use knot vectors $\Xi^{(\xi)}$ and $\Xi^{(\eta)}$ and degrees $p_\xi$, $p_\eta$.
 ### Open knot vectors
 
-A knot vector $\Xi = [\xi_1, \ldots, \xi_{n+p+1}]$ is an **open knot vector** (for degree $p$) when the first and last knots each have multiplicity $p+1$:
+A knot vector is open for degree $p$ when the first and last values each have multiplicity $p+1$,
 
 ```math
 \xi_1 = \cdots = \xi_{p+1},
@@ -48,47 +50,65 @@ A knot vector $\Xi = [\xi_1, \ldots, \xi_{n+p+1}]$ is an **open knot vector** (f
 \xi_{n+1} = \cdots = \xi_{n+p+1}.
 ```
 
-Equivalently, the parametric interval begins and ends at values $u_0 := \xi_1$ and $u_1 := \xi_{n+p+1}$ with maximal end multiplicity. Interior entries $\xi_{p+2}, \ldots, \xi_n$ may repeat but each interior knot typically has multiplicity at most $p$ so that the basis stays well posed (at least 1st order continuity).
-
-This is the standard choice in CAD and IGA, since an open knot vector makes the first and last B-spline basis functions behave like endpoint interpolants, so the curve or surface passes through the first and last rows of the control net. The active parameter range is usually taken as $\xi \in [\xi_{p+1}, \xi_{n+1}] = [u_0, u_1]$, i.e. between the first and last distinct knots.
+This is the standard choice in CAD and IGA. The first and last basis functions equal 1 at the ends, so the curve or surface passes through the first and last rows of control points. The active parameter range is $\xi \in [\xi_{p+1}, \xi_{n+1}]$, between the first and last distinct knots.
 
 ## NURBS
 
-**Non-uniform rational B-spline (NURBS)** curves augment the B-spline setup with a set of weights $w_A > 0$.
-One introduces the weight function (denominator in parametric space):
+A **non-uniform rational B-spline** (NURBS) uses the same knot vector and control points, together with weights $w_A > 0$. The weight function is
 
 ```math
-W(\xi) = \sum_{A=1}^{n} w_A \, \hat{N}_{A,p}(\xi)
+W(\xi) = \sum_{A=1}^{n} w_A \, \hat{N}_{A,p}(\xi),
 ```
 
-and defines the rational univariate basis functions:
+and the rational basis is
 
 ```math
 R_{A,p}(\xi) = \frac{w_A \, \hat{N}_{A,p}(\xi)}{W(\xi)}.
 ```
 
-These satisfy the same partition-of-unity property as B-splines,
+These functions still sum to one, $\sum_A R_{A,p}(\xi) = 1$. If all weights are equal, $R_{A,p} = \hat{N}_{A,p}$.
 
-```math
-\sum_{A=1}^{n} R_{A,p}(\xi) = 1,
-```
-
-and reduce to ordinary B-splines when all weights are equal (then $R_{A,p} = \hat{N}_{A,p}$).
-
-NURBS are used to define geometry in the same way as B-splines, but with $R_A$ in place of $N_A$. A NURBS surface is:
-
-```math
-\boldsymbol{S}(\xi,\eta) = \sum_{A=1}^{N} \boldsymbol{X}_A \, R_A(\xi, \eta)
-```
-
-where each $R_A$ corresponds to a control-net index pair $(i,j)$ as in the B-spline case. Using the same tensor-product B-spline factors $\hat{N}_{i}^{(\xi)}$, $\hat{N}_{j}^{(\eta)}$ and weights $w_{ij}$ on the control net, let $n_\xi$ and $n_\eta$ denote the numbers of univariate B-spline basis functions in the $\xi$- and $\eta$-directions, respectively. Then:
+A NURBS surface uses the same product of one-dimensional bases, with $R_A$ in place of $N_A$. With weights $w_{ij}$ on the control points,
 
 ```math
 W(\xi,\eta) = \sum_{i=1}^{n_\xi} \sum_{j=1}^{n_\eta} w_{ij} \, \hat{N}_{i}^{(\xi)}(\xi) \, \hat{N}_{j}^{(\eta)}(\eta),
 ```
 
 ```math
-R_A(\xi,\eta) = R_{ij}(\xi,\eta) = \frac{w_{ij} \, \hat{N}_{i}^{(\xi)}(\xi) \, \hat{N}_{j}^{(\eta)}(\eta)}{W(\xi,\eta)}.
+R_A(\xi,\eta) = R_{ij}(\xi,\eta) = \frac{w_{ij} \, \hat{N}_{i}^{(\xi)}(\xi) \, \hat{N}_{j}^{(\eta)}(\eta)}{W(\xi,\eta)},
 ```
 
-Thus NURBS surfaces share the same tensor-product structure as B-spline surfaces; the only change is the rational basis $R_A$ built from the B-spline tensor product and the weights. This family can represent exact curved conic sections (circles, ellipses, cylinders, etc.) that a polynomial B-spline basis cannot represent exactly in general. NURBS curves and NURBS solids use the same rational construction with one or three parametric directions, respectively.
+```math
+\boldsymbol{S}(\xi,\eta) = \sum_{A=1}^{N} \boldsymbol{X}_A \, R_A(\xi, \eta).
+```
+
+
+## Refinement
+
+The geometry is unchanged by the three operations below. They act on one parametric direction `dir` and rewrite copies of the knot vectors, control points, and weights. A new `NURBSMesh` is then built from those arrays.
+
+**h-refinement** inserts a knot (Boehm). `knotinsertion!(kv, orders, cp, w, ξ; dir)` inserts the value `ξ` once in direction `dir`. The number of elements in that direction increases by one if `ξ` was not already a knot. Continuity at a newly inserted simple knot is $C^{p-1}$. Inserting a value that is already present raises the multiplicity and lowers the continuity to $C^{p-m}$.
+
+**p-refinement** raises the polynomial degree by one (Piegl and Tiller, *The NURBS Book*, algorithm A5.9). `orders = orderelevation!(kv, orders, cp, w; dir)` returns the updated order tuple. End knots remain open (multiplicity $p+1$ at the new degree). Interior multiplicities increase by one as well, so $C^{p-m}$ is preserved.
+
+**k-refinement** raises the degree first and then inserts new knots (Hughes, Cottrell, and Bazilevs, 2005). `orders = smoothnesselevation!(kv, orders, cp, w, new_knots; dir)` calls `orderelevation!` once and then `knotinsertion!` for each entry of `new_knots`. Those new knots have multiplicity one at the elevated degree, so continuity there is $C^{p}$. 
+
+```julia
+mesh = generate_nurbs_patch(:hypercube, (1, 1), (2, 2); cornerpos=(0.0, 0.0), size=(2.0, 3.0))
+
+kv = (copy(mesh.knot_vectors[1]), copy(mesh.knot_vectors[2]))
+cp = copy(mesh.control_points)
+w  = copy(mesh.weights)
+orders = mesh.orders
+
+# h-refinement, insert ξ = 0 in the first parametric direction
+knotinsertion!(kv, orders, cp, w, 0.0; dir=1)
+
+# p-refinement, raise degree by one in that direction
+orders = orderelevation!(kv, orders, cp, w; dir=1)
+
+mesh = NURBSMesh(kv, orders, cp, w)
+grid = BezierGrid(mesh)
+```
+
+Copy the arrays before refining. The knot vectors and control points are rewritten in place. Build a new `NURBSMesh` afterwards so the element connectivity is up to date.

--- a/docs/src/splines.md
+++ b/docs/src/splines.md
@@ -1,6 +1,6 @@
 # Splines
 
-Isogeometric analysis uses B-splines and NURBS as the discrete basis. A one-dimensional spline is built from a knot vector and a polynomial degree. Surfaces and solids are products of these one-dimensional functions. Control points set the shape. NURBS add a positive weight at each control point, which is what allows exact circles and other conic sections.
+Isogeometric analysis uses B-splines and NURBS as the discrete approximation basis. A one-dimensional spline is built from a knot vector and a polynomial degree. Surfaces and solids are products of these one-dimensional functions. Control points set the shape. NURBS add a positive weight at each control point, which is what allows exact circles and other conic sections.
 
 The patch type is a `NURBSMesh`. After Bézier extraction, see [Bezier extraction](@ref), assembly follows the [Ferrite documentation](https://ferrite-fem.github.io/Ferrite.jl/stable/).
 
@@ -40,6 +40,7 @@ N_A(\xi, \eta) = \hat{N}_{i}^{(\xi)}(\xi) \, \hat{N}_{j}^{(\eta)}(\eta).
 ```
 
 The factors $\hat{N}_{i}^{(\xi)}$ and $\hat{N}_{j}^{(\eta)}$ use knot vectors $\Xi^{(\xi)}$ and $\Xi^{(\eta)}$ and degrees $p_\xi$, $p_\eta$.
+
 ### Open knot vectors
 
 A knot vector is open for degree $p$ when the first and last values each have multiplicity $p+1$,
@@ -66,7 +67,7 @@ and the rational basis is
 R_{A,p}(\xi) = \frac{w_A \, \hat{N}_{A,p}(\xi)}{W(\xi)}.
 ```
 
-These functions still sum to one, $\sum_A R_{A,p}(\xi) = 1$. If all weights are equal, $R_{A,p} = \hat{N}_{A,p}$.
+These functions sum to one, $\sum_A R_{A,p}(\xi) = 1$. If all weights are equal, $R_{A,p} = \hat{N}_{A,p}$.
 
 A NURBS surface uses the same product of one-dimensional bases, with $R_A$ in place of $N_A$. With weights $w_{ij}$ on the control points,
 

--- a/src/FerriteIGA.jl
+++ b/src/FerriteIGA.jl
@@ -28,6 +28,14 @@ const Optional{T} = Union{T, Nothing}
 const BezierExtractionOperator{T} = Vector{SparseArrays.SparseVector{T,Int}}
 const CoordsAndWeight{sdim,T} = Tuple{ <: AbstractVector{Vec{sdim,T}}, <: AbstractVector{T}}
 
+"""
+    BezierCoords
+
+Data for one cell, from `getcoordinates`.
+`x`, `w` are the NURBS points and weights.
+`xb`, `wb` are the Bézier points and weights.
+`beo` is the extraction operator.
+"""
 struct BezierCoords{dim_s,T} 
     xb   ::Vector{Vec{dim_s,T}}
     wb   ::Vector{T}
@@ -49,9 +57,11 @@ zero_bezier_coord(dim, T, nnodes) = BezierCoords{dim,T}(zeros(Vec{dim,T}, nnodes
 #Base.zero(Type{BezierCoords{dim,T}}) where {dim,T} = BezierCoords
 
 """
-    IGAInterpolation{shape, order} <: Ferrite.ScalarInterpolation{shape, order}
-"""
+    IGAInterpolation{shape, order}()
 
+Bernstein basis of degree `order` on `shape` (`RefLine`, `RefQuadrilateral`, or `RefHexahedron`).
+Use with `BezierCellValues`. For a 2D vector unknown write `ip^2`.
+"""
 struct IGAInterpolation{shape, order} <: Ferrite.ScalarInterpolation{shape, order}
     function IGAInterpolation{shape,order}() where {rdim, shape<:RefHypercube{rdim}, order} 
         #Check if you can construct a Bernstein basis
@@ -83,10 +93,9 @@ Ferrite.dirichlet_edgedof_indices(::IGAInterpolation{shape, order}) where {shape
 
 
 """
-    BezierCell{refshape,order,N} <: Ferrite.AbstractCell{refshape}
+    BezierCell{shape, order}(nodes)
 
-`N` = number of nodes/controlpoints
-`order` = tuple with order in each parametric dimension (does not need to be equal to `dim`)
+One cell of a `BezierGrid`. `nodes` are control-point numbers. `order` is the degree.
 """
 struct BezierCell{refshape,order,N} <: Ferrite.AbstractCell{refshape}
     nodes::NTuple{N,Int}

--- a/src/VTK.jl
+++ b/src/VTK.jl
@@ -25,6 +25,11 @@ let cache = Dict{Type{<:BezierCell}, Vector{Int}}()
 	end
 end
 
+"""
+    VTKIGAFile(filename, grid::BezierGrid)
+
+Write a `BezierGrid` to a `.vtu` file.
+"""
 struct VTKIGAFile{VTK<:WriteVTK.DatasetFile}
     vtk::VTK
 	cellset::Vector{Int}

--- a/src/bezier_grid.jl
+++ b/src/bezier_grid.jl
@@ -1,5 +1,13 @@
 export BezierGrid, getweights, getweights!, get_extraction_operator, get_bezier_coordinates, get_bezier_coordinates!, get_nurbs_coordinates
 
+"""
+    BezierGrid(mesh::NURBSMesh)
+    BezierGrid(grid::Grid)
+
+Ferrite grid with NURBS weights and an extraction operator on each cell.
+`BezierGrid(mesh)` builds this from a NURBS patch.
+`BezierGrid(grid)` wraps an ordinary Ferrite grid.
+"""
 struct BezierGrid{dim,C<:Ferrite.AbstractCell,T<:Real} <: Ferrite.AbstractGrid{dim}
 	grid    ::Ferrite.Grid{dim,C,T}
 	weights ::Vector{Float64}
@@ -175,6 +183,11 @@ function get_nurbs_coordinates(grid::BezierGrid{dim,C,T}, cell::Int) where {dim,
     return [grid.nodes[i].x for i in nodeidx]::Vector{Vec{dim,T}}
 end
 
+"""
+	get_extraction_operator(grid::BezierGrid, cellid)
+
+Bézier extraction operator for cell `cellid`.
+"""
 function get_extraction_operator(grid::BezierGrid, cellid::Int)
 	return grid.beo[cellid]
 end

--- a/src/mesh_generation.jl
+++ b/src/mesh_generation.jl
@@ -77,6 +77,13 @@ function Ferrite.generate_grid(::Type{<:BezierCell{RefHexahedron,order}}, nels::
 	return grid
 end
 
+"""
+    generate_nurbs_patch(name, nels, order; kwargs...)
+
+Build a NURBS patch. `name` is the geometry (`:plate_with_hole`, `:rectangle`, `:ring`, ...).
+`nels` is how many elements in each direction. `order` is the degree.
+The Meshes page lists every name and keyword.
+"""
 function generate_nurbs_patch(s::Symbol, nel::NTuple{N,Int}, order::Int; kwargs...) where N
 	orders = ntuple(i->order, N)
 	generate_nurbs_patch(Val{s}(), nel, orders; kwargs...)

--- a/src/nurbsmesh.jl
+++ b/src/nurbsmesh.jl
@@ -1,7 +1,11 @@
 export NURBSMesh, parent_to_parametric_map, eval_parametric_coordinate
+export knotinsertion!, orderelevation!, smoothnesselevation!
 
 """
-Defines a NURBS patch, containing knot vectors, orders, controlpoints, weights and connectivity arrays.
+	NURBSMesh(knot_vectors, orders, control_points, weights=ones(...))
+
+A NURBS or B-spline patch. `knot_vectors` and `orders` give the basis in each direction.
+`control_points` give the shape. `weights` are all ones for a B-spline.
 """
 struct NURBSMesh{pdim,sdim,T} #<: Ferrite.AbstractGrid
 	knot_vectors::NTuple{pdim,Vector{T}}
@@ -54,14 +58,12 @@ function Ferrite.getcoordinates(mesh::NURBSMesh, ie::Int)
 end
 
 """
-	eval_parametric_coordinate(mesh::NURBSMesh{pdim,sdim}, ξ::Vec{pdim}) where {pdim,sdim}
+	eval_parametric_coordinate(mesh::NURBSMesh, ξ)
 
-Given a coordinate `ξ` in the parametric domain in the parametric, this function 
-returns the corresponding coordinate in the global domain.
+Physical point corresponding to the parameter `ξ` on the patch.
 
 TODO: This function is currently very in-effecient for large domain.
 """
-
 function eval_parametric_coordinate(mesh::NURBSMesh{pdim,sdim}, ξ::Vec{pdim}) where {pdim,sdim}
 
 	bspline = BSplineBasis(mesh.knot_vectors, mesh.orders)
@@ -156,7 +158,11 @@ function generate_nurbs_meshdata(orders::NTuple{dim,Int}, nbf::NTuple{dim,Int}) 
 	return nel, nnp, nen, INN, IEN
 end
 
-#knot insertion algorithm that uses Boehm's algorithm for knot insertion h-refinement
+"""
+	knotinsertion!(knot_vectors, orders, control_points, weights, ξ; dir)
+
+h-refinement. Insert the knot `ξ` once in parametric direction `dir` (Boehm).
+"""
 function knotinsertion!(knot_vectors::NTuple{pdim,Vector{T}}, orders::NTuple{pdim,Int}, control_points::Vector{Vec{sdim,T}}, weights::Vector{T}, ξᴺ::T; dir::Int) where {pdim,sdim,T}
 
 	Ξ = knot_vectors[dir]
@@ -209,7 +215,11 @@ function knotinsertion!(knot_vectors::NTuple{pdim,Vector{T}}, orders::NTuple{pdi
 	return nothing
 end
 
-#p-refinement: raise degree by one using the algorithm A5.9, Piegl & Tiller in "The NURBS Book"
+"""
+	orderelevation!(knot_vectors, orders, control_points, weights; dir)
+
+p-refinement. Raise the polynomial degree by one in direction `dir`.
+"""
 function orderelevation!(knot_vectors::NTuple{pdim,Vector{T}}, orders::NTuple{pdim,Int}, control_points::Vector{Vec{sdim,T}}, weights::Vector{T}; dir::Int) where {pdim,sdim,T}
 
 	Ξ = knot_vectors[dir]
@@ -408,7 +418,12 @@ function orderelevation!(knot_vectors::NTuple{pdim,Vector{T}}, orders::NTuple{pd
 	return ntuple(i -> i == dir ? orders[i] + 1 : orders[i], pdim)
 end
 
-#raises global smoothness by 1 degree, first performs polynomial degree elevation then the corresponding knot insertion
+"""
+	smoothnesselevation!(knot_vectors, orders, control_points, weights, new_knots; dir)
+
+k-refinement. Raise the degree by one in direction `dir`, then insert each knot in `new_knots`.
+This is a pointwise smoothness elevation. 
+"""
 function smoothnesselevation!(knot_vectors::NTuple{pdim,Vector{T}}, orders::NTuple{pdim,Int}, control_points::Vector{Vec{sdim,T}}, weights::Vector{T}, new_knots::AbstractVector{T}; dir::Int) where {pdim,sdim,T}
 	orders = orderelevation!(knot_vectors, orders, control_points, weights; dir=dir)
 	for ξᴺ in new_knots

--- a/src/splines/bezier.jl
+++ b/src/splines/bezier.jl
@@ -1,14 +1,11 @@
 export Bernstein
 
 """
-    Bernstein{dim,order}()
+    Bernstein{shape, order}()
 
-The Bertnstein polynominal spline basis. Usually used as the cell interpolation in 
-IGA, together with bezier extraction + BezierValues.
-
-`dim` - The spacial dimentsion of the interpolation
-`order` - A tuple with the order in each parametric direction. 
-"""  
+Bernstein polynomials of degree `order` on the reference `shape`.
+`IGAInterpolation` uses this basis on each cell after Bézier extraction.
+"""
 struct Bernstein{shape, order} <: Ferrite.ScalarInterpolation{shape, order}
     function Bernstein{shape,order}() where {rdim, shape<:RefHypercube{rdim}, order} 
         @assert order isa Int

--- a/src/splines/bezier_values.jl
+++ b/src/splines/bezier_values.jl
@@ -10,6 +10,12 @@ function Ferrite.default_geometric_interpolation(::Bernstein{shape, order}) wher
     return VectorizedInterpolation{dim}(Bernstein{shape, order}())
 end
 
+"""
+    BezierCellValues(qr, ip)
+
+Shape values on an IGA cell. Call `reinit!(cv, coords)` first. Then `shape_value` and
+`shape_gradient` return NURBS values.
+"""
 struct BezierCellValues{FV, GM, QR, T} <: Ferrite.AbstractCellValues
     bezier_values::FV # FunctionValues
     tmp_values::FV    # FunctionValues
@@ -22,6 +28,11 @@ struct BezierCellValues{FV, GM, QR, T} <: Ferrite.AbstractCellValues
     current_w::Vector{T}
 end
 
+"""
+    BezierFacetValues(fqr, ip)
+
+Shape values on an IGA face. Call `reinit!(fv, coords, faceid)` first.
+"""
 struct BezierFacetValues{FV, GM, FQR, dim, T, V_FV<:AbstractVector{FV}, V_GM<:AbstractVector{GM}} <: Ferrite.AbstractFacetValues
     bezier_values::V_FV # FunctionValues
     tmp_values::V_FV    # FunctionValues


### PR DESCRIPTION
## Summary

Rewrote the public docs so the package is easier to start with.

- README and docs homepage are more substantial now. 
- Splines page updated to be better and with the smoothness/order/knot insertions
- Bézier extraction page and the current types (all the methods and how to use them)
- Mesh catalog for the different types of meshes
- API page from Julia docstrings so readability is better
- Removed the empty `bezier_values.md` docs and put the explainations in the other part

I would like some feedback and whether anything in the extraction / refinement pages is off.

## Registration

The package is still unregistered. With the docs and the recent refinement work, do you think it is in shape to be so or is it too early?Theres probably work before a clean registration (compat bounds for ex or some APIs). I can make a checklist and start on it if thats a good idea. 